### PR TITLE
Add advanced caption filter to profile captions view

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -147,7 +147,13 @@
     "roleAssignmentSuccess": "Updated!",
     "roleAssignmentFailure": "Failed to update: {{error}}",
     "filterByTags": "Filter by tags (up to {{maxTags}})",
-    "noTags": "No tags"
+    "noTags": "No tags",
+    "advancedFilter": {
+      "label": "Caption type",
+      "all": "All",
+      "advanced": "Advanced only",
+      "nonAdvanced": "Non-advanced only"
+    }
   },
   "viewer": {
     "browseOtherCaptions": "Browse other captions",

--- a/src/common/caption-utils.ts
+++ b/src/common/caption-utils.ts
@@ -9,12 +9,12 @@ export const hasTag = (tags: string[], tag: string) => {
 };
 
 export const getCaptionCues = (
-  captions: CaptionDataContainer
+  captions: CaptionDataContainer,
 ): NekoCaption[] => {
   if (!captions || !captions.tracks) {
     return [];
   }
-  return captions.tracks.reduce((acc, track) => {
+  return captions.tracks.reduce<NekoCaption[]>((acc, track) => {
     return [...acc, ...track.cues];
   }, []);
 };

--- a/src/common/feature/captioner/sagas.ts
+++ b/src/common/feature/captioner/sagas.ts
@@ -25,13 +25,14 @@ import { LoadCaptionListResult } from "../video/types";
 import { Locator } from "@/common/locator/locator";
 
 function* loadUserCaptionsRequestSaga(
-  action: PayloadAction<CaptionsPagedRequest>
+  action: PayloadAction<CaptionsPagedRequest>,
 ) {
   const isLoggedIn = yield select(isLoggedInSelector);
   if (!isLoggedIn) {
     throw new Error("You must be logged in to perform this action!");
   }
-  const { pageNumber, pageSize, captionerId, tags } = action.payload;
+  const { pageNumber, pageSize, captionerId, tags, advancedFilter } =
+    action.payload;
 
   const { captions, hasMore }: LoadCaptionListResult = yield call(
     [Locator.provider(), "loadUserCaptions"],
@@ -39,11 +40,12 @@ function* loadUserCaptionsRequestSaga(
       ...getLimitOffsetFromPagination(pageSize, pageNumber),
       captionerId,
       tags,
-    }
+      advancedFilter,
+    },
   );
 
   yield put(
-    loadUserCaptions.success({ pageNumber, pageSize, captions, hasMore })
+    loadUserCaptions.success({ pageNumber, pageSize, captions, hasMore }),
   );
 }
 
@@ -54,7 +56,7 @@ function* loadUserCaptionsSuccessSaga({
 }
 
 function* loadPrivateCaptionerDataRequestSaga(
-  action: PayloadAction<LoadPrivateCaptionerDataRequestParams>
+  action: PayloadAction<LoadPrivateCaptionerDataRequestParams>,
 ) {
   const params = action.payload;
   const isLoggedIn = yield select(isLoggedInSelector);
@@ -64,7 +66,7 @@ function* loadPrivateCaptionerDataRequestSaga(
   }
   const privateData: PrivateCaptionerData = yield call(
     [Locator.provider(), "loadPrivateCaptionerData"],
-    params
+    params,
   );
   const { captioner, privateProfile, captions } = privateData;
   if (!captioner || !privateProfile || !captions) {
@@ -80,7 +82,7 @@ function* loadPrivateCaptionerDataSuccessSaga({
 }
 
 function* updateCaptionerProfileRequestSaga(
-  action: PayloadAction<UpdateCaptionerProfileParams>
+  action: PayloadAction<UpdateCaptionerProfileParams>,
 ) {
   const params = action.payload;
   const isLoggedIn = yield select(isLoggedInSelector);
@@ -90,7 +92,7 @@ function* updateCaptionerProfileRequestSaga(
   }
   const privateData: PrivateCaptionerData = yield call(
     [Locator.provider(), "updateCaptionerProfile"],
-    params
+    params,
   );
   const { captioner, privateProfile, captions } = privateData;
   if (!captioner || !privateProfile || !captions) {
@@ -109,7 +111,7 @@ function* deleteServerCaptionSaga(action: PayloadAction<string>) {
   const captionId = action.payload;
   const result: ServerResponse = yield call(
     [Locator.provider(), "deleteCaption"],
-    captionId
+    captionId,
   );
   if (result.status === "error") {
     throw new Error(result.error);
@@ -123,28 +125,28 @@ function* deleteServerCaptionSaga(action: PayloadAction<string>) {
 export function* captionerSaga() {
   yield takeLatest(
     loadUserCaptions.REQUEST,
-    loadUserCaptions.requestSaga(loadUserCaptionsRequestSaga)
+    loadUserCaptions.requestSaga(loadUserCaptionsRequestSaga),
   );
   yield takeLatest(loadUserCaptions.SUCCESS, safe(loadUserCaptionsSuccessSaga));
   yield takeLatest(
     loadPrivateCaptionerData.REQUEST,
-    loadPrivateCaptionerData.requestSaga(loadPrivateCaptionerDataRequestSaga)
+    loadPrivateCaptionerData.requestSaga(loadPrivateCaptionerDataRequestSaga),
   );
   yield takeLatest(
     loadPrivateCaptionerData.SUCCESS,
-    safe(loadPrivateCaptionerDataSuccessSaga)
+    safe(loadPrivateCaptionerDataSuccessSaga),
   );
   yield takeLatest(
     updateCaptionerProfile.REQUEST,
-    updateCaptionerProfile.requestSaga(updateCaptionerProfileRequestSaga)
+    updateCaptionerProfile.requestSaga(updateCaptionerProfileRequestSaga),
   );
   yield takeLatest(
     deleteServerCaption.REQUEST,
-    deleteServerCaption.requestSaga(deleteServerCaptionSaga)
+    deleteServerCaption.requestSaga(deleteServerCaptionSaga),
   );
   yield takeLatest(
     updateCaptionerProfile.SUCCESS,
-    safe(updateCaptionerProfileSuccessSaga)
+    safe(updateCaptionerProfileSuccessSaga),
   );
 }
 

--- a/src/common/feature/captioner/types.ts
+++ b/src/common/feature/captioner/types.ts
@@ -1,6 +1,8 @@
 import { OffsetRequest, PagedType, ServerResponse } from "@/common/types";
 import { CaptionListFields } from "../video/types";
 
+export type AdvancedFilter = "all" | "advanced" | "nonAdvanced";
+
 // For all captioner (logged in user) related data
 export type CaptionerState = {
   captions?: CaptionListFields[];
@@ -40,6 +42,7 @@ export type CaptionsResponse = ServerResponse & {
 export type CaptionsPagedRequest = PagedType & {
   captionerId: string;
   tags?: string[];
+  advancedFilter?: AdvancedFilter;
 };
 
 export type CaptionsPagedResult = PagedType & {
@@ -50,6 +53,7 @@ export type CaptionsPagedResult = PagedType & {
 export type CaptionsRequest = OffsetRequest & {
   captionerId: string;
   tags?: string[];
+  advancedFilter?: AdvancedFilter;
 };
 
 export type RoleRequest = {

--- a/src/common/feature/profile/reducers.ts
+++ b/src/common/feature/profile/reducers.ts
@@ -33,7 +33,7 @@ export const profileReducer = createReducer<ProfileState>(
         return {
           ...state,
           captions: captions || [],
-          captioner,
+          captioner: captioner ?? null,
         };
       })
       .addCase(setListedCaptions, (state, action) => {
@@ -60,5 +60,5 @@ export const profileReducer = createReducer<ProfileState>(
           ...action.payload.profile,
         };
       });
-  }
+  },
 );

--- a/src/common/feature/profile/sagas.ts
+++ b/src/common/feature/profile/sagas.ts
@@ -41,7 +41,7 @@ function* loadProfileRequestSaga({
 }: PayloadAction<LoadProfileParams>) {
   const profile: PublicProfileData = yield call(
     [Locator.provider(), "loadProfile"],
-    payload
+    payload,
   );
 
   yield put(loadProfile.success(profile));
@@ -54,22 +54,28 @@ function* loadProfileSuccessSaga({
 }
 
 function* loadUserCaptionsRequestSaga(
-  action: PayloadAction<CaptionsPagedRequest>
+  action: PayloadAction<CaptionsPagedRequest>,
 ) {
   const {
     pageNumber,
     pageSize,
     captionerId: captionerId,
     tags,
+    advancedFilter,
   } = action.payload;
 
   const { captions, hasMore }: LoadCaptionListResult = yield call(
     [Locator.provider(), "loadUserCaptions"],
-    { ...getLimitOffsetFromPagination(pageSize, pageNumber), captionerId, tags }
+    {
+      ...getLimitOffsetFromPagination(pageSize, pageNumber),
+      captionerId,
+      tags,
+      advancedFilter,
+    },
   );
 
   yield put(
-    loadUserCaptions.success({ pageNumber, pageSize, captions, hasMore })
+    loadUserCaptions.success({ pageNumber, pageSize, captions, hasMore }),
   );
 }
 
@@ -84,7 +90,7 @@ function* updateProfileRequestSaga({
 }: PayloadAction<EditProfileFields>) {
   const privateData: PrivateCaptionerData = yield call(
     [Locator.provider(), "updateCaptionerProfile"],
-    { ...payload, name: "" }
+    { ...payload, name: "" },
   );
 
   yield put(updateProfile.success(privateData));
@@ -94,9 +100,8 @@ function* updateProfileSuccessSaga({
   payload,
 }: PayloadAction<PrivateCaptionerData>) {
   const { captioner, privateProfile } = payload;
-  const { captions: captions }: CaptionerState = yield select(
-    captionerSelector
-  );
+  const { captions: captions }: CaptionerState =
+    yield select(captionerSelector);
   if (!privateProfile || !captioner) {
     console.error("No captioner data found.");
     return;
@@ -106,22 +111,20 @@ function* updateProfileSuccessSaga({
       captions: captions || [],
       privateProfile,
       captioner,
-    })
+    }),
   );
 }
 
 function* reloadUserId(userId: string) {
   // Update the loaded data
-  const { captioner: profileCaptioner }: ProfileState = yield select(
-    profileSelector
-  );
+  const { captioner: profileCaptioner }: ProfileState =
+    yield select(profileSelector);
   if (profileCaptioner && profileCaptioner.userId === userId) {
     yield put(loadProfile.request({ profileId: userId, withCaptions: true }));
   }
 
-  const { captioner: userCaptioner }: CaptionerState = yield select(
-    captionerSelector
-  );
+  const { captioner: userCaptioner }: CaptionerState =
+    yield select(captionerSelector);
   if (userCaptioner && userCaptioner.userId === userId) {
     yield put(loadPrivateCaptionerData.request({ withCaptions: true }));
   }
@@ -132,7 +135,7 @@ function* assignReviewerManagerRequestSaga({
 }: PayloadAction<string>) {
   const response: ServerResponse = yield call(
     [Locator.provider(), "assignReviewerManager"],
-    { targetUserId }
+    { targetUserId },
   );
   if (response.status === "error") {
     throw new Error(response.error);
@@ -148,7 +151,7 @@ function* assignReviewerRequestSaga({
 }: PayloadAction<string>) {
   const response: ServerResponse = yield call(
     [Locator.provider(), "assignReviewer"],
-    { targetUserId }
+    { targetUserId },
   );
   if (response.status === "error") {
     throw new Error(response.error);
@@ -164,7 +167,7 @@ function* verifyCaptionerRequestSaga({
 }: PayloadAction<string>) {
   const response: ServerResponse = yield call(
     [Locator.provider(), "verifyCaptioner"],
-    { targetUserId }
+    { targetUserId },
   );
   if (response.status === "error") {
     throw new Error(response.error);
@@ -179,7 +182,7 @@ function* banCaptionerRequestSaga({
 }: PayloadAction<string>) {
   const response: ServerResponse = yield call(
     [Locator.provider(), "banCaptioner"],
-    { targetUserId }
+    { targetUserId },
   );
   if (response.status === "error") {
     throw new Error(response.error);
@@ -192,39 +195,39 @@ function* banCaptionerRequestSaga({
 function* profileSaga() {
   yield takeLatest(
     loadProfile.REQUEST,
-    loadProfile.requestSaga(loadProfileRequestSaga)
+    loadProfile.requestSaga(loadProfileRequestSaga),
   );
   yield takeLatest(loadProfile.SUCCESS, safe(loadProfileSuccessSaga));
 
   yield takeLatest(
     loadUserCaptions.REQUEST,
-    loadUserCaptions.requestSaga(loadUserCaptionsRequestSaga)
+    loadUserCaptions.requestSaga(loadUserCaptionsRequestSaga),
   );
   yield takeLatest(loadUserCaptions.SUCCESS, safe(loadUserCaptionsSuccessSaga));
 
   yield takeLatest(
     updateProfile.REQUEST,
-    updateProfile.requestSaga(updateProfileRequestSaga)
+    updateProfile.requestSaga(updateProfileRequestSaga),
   );
   yield takeLatest(updateProfile.SUCCESS, safe(updateProfileSuccessSaga));
 
   yield takeLatest(
     assignReviewerManager.REQUEST,
-    assignReviewerManager.requestSaga(assignReviewerManagerRequestSaga)
+    assignReviewerManager.requestSaga(assignReviewerManagerRequestSaga),
   );
   yield takeLatest(
     assignReviewer.REQUEST,
-    assignReviewer.requestSaga(assignReviewerRequestSaga)
+    assignReviewer.requestSaga(assignReviewerRequestSaga),
   );
 
   yield takeLatest(
     verifyCaptioner.REQUEST,
-    verifyCaptioner.requestSaga(verifyCaptionerRequestSaga)
+    verifyCaptioner.requestSaga(verifyCaptionerRequestSaga),
   );
 
   yield takeLatest(
     banCaptioner.REQUEST,
-    banCaptioner.requestSaga(banCaptionerRequestSaga)
+    banCaptioner.requestSaga(banCaptionerRequestSaga),
   );
 }
 

--- a/src/common/feature/profile/types.ts
+++ b/src/common/feature/profile/types.ts
@@ -17,7 +17,7 @@ export type LoadProfileParams = {
 
 export type PublicProfileData = {
   captions?: CaptionListFields[];
-  captioner: CaptionerFields;
+  captioner?: CaptionerFields;
 };
 
 export type EditProfileFields = {

--- a/src/web/feature/profile/components/profile.tsx
+++ b/src/web/feature/profile/components/profile.tsx
@@ -1,5 +1,6 @@
 import { colors } from "@/common/colors";
 import {
+  AdvancedFilter,
   CaptionerFields,
   CaptionerPrivateFields,
 } from "@/common/feature/captioner/types";
@@ -22,7 +23,16 @@ import {
   faUsers,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Layout, message, Select, Space, Tag, Tooltip, Typography } from "antd";
+import {
+  Layout,
+  message,
+  Segmented,
+  Select,
+  Space,
+  Tag,
+  Tooltip,
+  Typography,
+} from "antd";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import { ReactElement, useEffect, useMemo, useRef, useState } from "react";
@@ -113,7 +123,12 @@ type ProfileProps = {
   isEditing?: boolean;
   canEdit?: boolean;
   hasMore: boolean; // has more captions to load
-  onChangePage?: (page: number, pageSize?: number, tags?: string[]) => void;
+  onChangePage?: (
+    page: number,
+    pageSize?: number,
+    tags?: string[],
+    advancedFilter?: AdvancedFilter,
+  ) => void;
   onDelete?: (caption: CaptionListFields) => void;
   onDownloadCaption?: (captionId: string) => void;
   onSetEditing?: (isEditing: boolean) => void;
@@ -123,7 +138,7 @@ type ProfileProps = {
   onAssignReviewer: () => void;
   onVerifyCaptioner: () => void;
   onBanCaptioner: () => void;
-  onSetFilteredTags: (tags: string[]) => void;
+  onSetFilters: (tags: string[], advancedFilter: AdvancedFilter) => void;
   onUpdateCaption: (captionId: string) => void;
 };
 
@@ -162,7 +177,7 @@ export const Profile = ({
   onBanCaptioner = () => {
     /*do nothing*/
   },
-  onSetFilteredTags,
+  onSetFilters,
   onUpdateCaption,
 }: ProfileProps): ReactElement => {
   const { t } = useTranslation("common");
@@ -187,6 +202,8 @@ export const Profile = ({
   }, [captionTags]);
 
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [advancedFilter, setAdvancedFilterState] =
+    useState<AdvancedFilter>("all");
 
   const router = useRouter();
   const hasPerformedInitialFilter = useRef(false);
@@ -197,20 +214,29 @@ export const Profile = ({
       return;
     }
     hasPerformedInitialFilter.current = true;
+
+    const advancedQuery = router.query.advanced;
+    const initialAdvanced: AdvancedFilter =
+      advancedQuery === "advanced" || advancedQuery === "nonAdvanced"
+        ? advancedQuery
+        : "all";
+
     let defaultFilterTagNames = router.query.tags || "";
-    if (!defaultFilterTagNames) {
-      return;
-    }
     if (typeof defaultFilterTagNames === "string") {
-      defaultFilterTagNames = [defaultFilterTagNames];
+      defaultFilterTagNames = defaultFilterTagNames
+        ? [defaultFilterTagNames]
+        : [];
     }
     const defaultTags = existingTags
       .filter((tag) => {
         return tag.name && defaultFilterTagNames.includes(tag.name);
       })
       .map((tag) => tag.tag);
-    if (defaultTags.length > 0) {
-      handleChangeTagFilter(defaultTags);
+
+    if (defaultTags.length > 0 || initialAdvanced !== "all") {
+      setSelectedTags(defaultTags);
+      setAdvancedFilterState(initialAdvanced);
+      onSetFilters(defaultTags, initialAdvanced);
     }
   }, [existingTags]);
 
@@ -219,8 +245,8 @@ export const Profile = ({
     (currentCaptionPage - 1) * CAPTION_LIST_PAGE_SIZE +
     (hasMore ? 1 : 0);
 
-  const currentCaptionListCount =
-    selectedTags.length > 0 ? filteredCount : captionCount;
+  const isFiltering = selectedTags.length > 0 || advancedFilter !== "all";
+  const currentCaptionListCount = isFiltering ? filteredCount : captionCount;
 
   const handleCopyProfileLink = () => {
     if (navigator && navigator.clipboard) {
@@ -237,9 +263,7 @@ export const Profile = ({
     router.push(routeNames.captioner.settings);
   };
 
-  const handleChangeTagFilter = (tags: string[]) => {
-    setSelectedTags(tags);
-    onSetFilteredTags(tags);
+  const syncFiltersToUrl = (tags: string[], advanced: AdvancedFilter) => {
     const newUrl = new URL(window.location.href);
     newUrl.search = "";
     if (tags.length > 0) {
@@ -247,11 +271,26 @@ export const Profile = ({
         newUrl.searchParams.append("tags", getCaptionGroupTagName(tag));
       });
     }
+    if (advanced !== "all") {
+      newUrl.searchParams.set("advanced", advanced);
+    }
     window.history.pushState({}, document.title, newUrl);
   };
 
+  const handleChangeTagFilter = (tags: string[]) => {
+    setSelectedTags(tags);
+    onSetFilters(tags, advancedFilter);
+    syncFiltersToUrl(tags, advancedFilter);
+  };
+
+  const handleChangeAdvancedFilter = (value: AdvancedFilter) => {
+    setAdvancedFilterState(value);
+    onSetFilters(selectedTags, value);
+    syncFiltersToUrl(selectedTags, value);
+  };
+
   const handleOnChangePage = (page: number, pageSize: number) => {
-    onChangePage?.(page, pageSize, selectedTags);
+    onChangePage?.(page, pageSize, selectedTags, advancedFilter);
   };
 
   return (
@@ -349,6 +388,24 @@ export const Profile = ({
               <div style={{ padding: "40px 40px" }}>
                 <Title level={3}>{t("profile.contributedCaptions")}</Title>
                 {/* do a client check to prevent ssr issues */}
+                {inClient && (
+                  <Segmented<AdvancedFilter>
+                    style={{ marginBottom: 6 }}
+                    value={advancedFilter}
+                    onChange={handleChangeAdvancedFilter}
+                    options={[
+                      { label: t("profile.advancedFilter.all"), value: "all" },
+                      {
+                        label: t("profile.advancedFilter.advanced"),
+                        value: "advanced",
+                      },
+                      {
+                        label: t("profile.advancedFilter.nonAdvanced"),
+                        value: "nonAdvanced",
+                      },
+                    ]}
+                  />
+                )}
                 {inClient && (
                   <Select
                     mode="multiple"

--- a/src/web/feature/profile/containers/captioner-profile.tsx
+++ b/src/web/feature/profile/containers/captioner-profile.tsx
@@ -1,6 +1,7 @@
 import { exportCaption } from "@/common/feature/caption-editor/export-caption";
 import { deleteServerCaption } from "@/common/feature/captioner/actions";
 import { captionerSelector } from "@/common/feature/captioner/selectors";
+import { AdvancedFilter } from "@/common/feature/captioner/types";
 import {
   assignReviewer,
   assignReviewerManager,
@@ -58,6 +59,7 @@ export const CaptionerProfile = () => {
     page: number,
     pageSize: number = CAPTION_LIST_PAGE_SIZE,
     tags?: string[],
+    advancedFilter?: AdvancedFilter,
   ) => {
     dispatch(
       loadUserCaptions.request({
@@ -65,6 +67,7 @@ export const CaptionerProfile = () => {
         pageNumber: page,
         captionerId,
         tags,
+        advancedFilter,
       }),
     );
   };
@@ -89,8 +92,8 @@ export const CaptionerProfile = () => {
     }
   };
 
-  const handleSetFilteredTags = (tags: string[]) => {
-    handleChangeCaptionPage(1, CAPTION_LIST_PAGE_SIZE, tags);
+  const handleSetFilters = (tags: string[], advancedFilter: AdvancedFilter) => {
+    handleChangeCaptionPage(1, CAPTION_LIST_PAGE_SIZE, tags, advancedFilter);
   };
 
   const handleUpdateCaption = () => {
@@ -122,7 +125,7 @@ export const CaptionerProfile = () => {
       onAssignReviewer={handleAssignReviewer(captionerId, dispatch)}
       onVerifyCaptioner={handleVerifyCaptioner(captionerId, dispatch)}
       onBanCaptioner={handleBanCaptioner(captionerId, dispatch)}
-      onSetFilteredTags={handleSetFilteredTags}
+      onSetFilters={handleSetFilters}
       onUpdateCaption={handleUpdateCaption}
     />
   );

--- a/src/web/feature/profile/containers/own-profile.tsx
+++ b/src/web/feature/profile/containers/own-profile.tsx
@@ -5,6 +5,7 @@ import {
   loadPrivateCaptionerData,
 } from "@/common/feature/captioner/actions";
 import { captionerSelector } from "@/common/feature/captioner/selectors";
+import { AdvancedFilter } from "@/common/feature/captioner/types";
 import {
   assignReviewer,
   assignReviewerManager,
@@ -85,6 +86,7 @@ export const OwnProfile = (): ReactElement => {
     page: number,
     pageSize = 1,
     tags?: string[],
+    advancedFilter?: AdvancedFilter,
   ) => {
     dispatch(
       loadLoggedInUserCaptions.request({
@@ -92,6 +94,7 @@ export const OwnProfile = (): ReactElement => {
         pageNumber: page,
         captionerId,
         tags,
+        advancedFilter,
       }),
     );
   };
@@ -131,8 +134,8 @@ export const OwnProfile = (): ReactElement => {
     setIsEditing(false);
   };
 
-  const handleSetFilteredTags = (tags: string[]) => {
-    handleChangeCaptionPage(1, CAPTION_LIST_PAGE_SIZE, tags);
+  const handleSetFilters = (tags: string[], advancedFilter: AdvancedFilter) => {
+    handleChangeCaptionPage(1, CAPTION_LIST_PAGE_SIZE, tags, advancedFilter);
   };
 
   const handleUpdateCaption = () => {
@@ -168,7 +171,7 @@ export const OwnProfile = (): ReactElement => {
       onAssignReviewer={handleAssignReviewer(captionerId, dispatch)}
       onVerifyCaptioner={handleVerifyCaptioner(captionerId, dispatch)}
       onBanCaptioner={handleBanCaptioner(captionerId, dispatch)}
-      onSetFilteredTags={handleSetFilteredTags}
+      onSetFilters={handleSetFilters}
       onUpdateCaption={handleUpdateCaption}
     />
   );


### PR DESCRIPTION
## Summary
This PR adds the ability to filter captions by type (advanced vs non-advanced) in the profile captions view, complementing the existing tag-based filtering.

## Key Changes
- **New filter type**: Introduced `AdvancedFilter` type with three options: "all", "advanced", and "nonAdvanced"
- **UI component**: Added a `Segmented` control to the profile page allowing users to filter captions by type
- **State management**: Extended caption loading requests to include the `advancedFilter` parameter throughout the saga layer
- **URL persistence**: Updated URL query parameters to persist both tag filters and advanced filter selections
- **Filter initialization**: Enhanced initial filter loading from URL query parameters to support both tags and advanced filter
- **Callback updates**: Renamed `onSetFilteredTags` to `onSetFilters` to reflect the expanded filtering capability
- **Localization**: Added translation strings for the new filter options

## Implementation Details
- The advanced filter state is managed alongside the existing tag filter state in the Profile component
- Both filters are synchronized with the URL using query parameters (`tags` and `advanced`)
- The `syncFiltersToUrl` function consolidates URL update logic for both filter types
- Filter changes trigger page resets to ensure consistent pagination with filtered results
- The implementation maintains backward compatibility by defaulting to "all" when no advanced filter is specified

https://claude.ai/code/session_01ESQVb16hkApiYwedA6dwua