### PR TITLE
fix: rely on ISR cache for homepage latest captions

### DIFF
--- a/src/web/feature/home/home.tsx
+++ b/src/web/feature/home/home.tsx
@@ -1,7 +1,4 @@
-import {
-  loadLatestCaptions,
-  loadLatestUserLanguageCaptions,
-} from "@/common/feature/public-dashboard/actions";
+import { loadLatestUserLanguageCaptions } from "@/common/feature/public-dashboard/actions";
 import { publicDashboardSelector } from "@/common/feature/public-dashboard/selectors";
 import { getBaseLanguageCode } from "@/common/languages";
 import React, { ReactElement, useEffect, useState } from "react";
@@ -19,17 +16,10 @@ export const Home = (): ReactElement => {
   const { latestCaptions, latestUserLanguageCaptions } = useSelector(
     publicDashboardSelector,
   );
-  const isLoadingLatest = useSelector(loadLatestCaptions.isLoading(undefined));
   const isLoadingLang = useSelector(
     loadLatestUserLanguageCaptions.isLoading(undefined),
   );
   const [langOverride, setLangOverride] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (latestCaptions.length === 0) {
-      dispatch(loadLatestCaptions.request());
-    }
-  }, []);
 
   useEffect(() => {
     const lang = navigator.language;
@@ -52,7 +42,7 @@ export const Home = (): ReactElement => {
       >
         <IntroSplit
           captions={latestCaptions.slice(0, 6)}
-          isLoading={isLoadingLatest}
+          isLoading={false}
         />
         <SitesMarquee />
         <FeaturesGrid />


### PR DESCRIPTION
## Summary
- The homepage's "latest from the community" section was visibly reloading on every page load because `Home` dispatched `loadLatestCaptions.request()` on mount, which flipped `isLoadingLatest` to true and rendered a spinner over already-hydrated SSG data.
- `pages/index.tsx` already runs `loadLatestCaptionsApi` in `getStaticProps` with `revalidate: 90`, so the data is served from Next.js's ISR cache. The client-side refetch was redundant.
- Removed the `useEffect` and related `isLoadingLatest` selector from `src/web/feature/home/home.tsx`. `IntroSplit` now reads `latestCaptions` straight from the hydrated store with `isLoading={false}`.
- The language-specific list (`latestUserLanguageCaptions`) is intentionally left fetching on the client, since it depends on `navigator.language` rather than the page locale.

## Test plan
- [ ] Load `/` and confirm the latest-captions tiles render immediately without a spinner flash.
- [ ] Network tab: confirm no `loadLatestCaptions` Parse Cloud call is made on the client when navigating to `/`.
- [ ] Confirm the user-language rail still loads as before.
- [ ] After 90s, refresh and confirm the page is regenerated in the background (ISR still working).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Juf3xKU6RF8RzdHHgSK4XP)_