### PR TITLE
Add caption preview feature for sharing captions without uploading

### DIFF
--- a/pages/view/preview.tsx
+++ b/pages/view/preview.tsx
@@ -1,0 +1,40 @@
+import { Main } from "@/web/feature/home/main";
+import { CaptionPreviewPage } from "@/web/feature/viewer/caption-preview-page";
+import { NextWrapper } from "@/web/next-helpers/page-wrapper";
+import { wrapper } from "@/web/store/store";
+import { GetStaticProps } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import Head from "next/head";
+import { useRouter } from "next/router";
+
+const TRANSLATION_NAMESPACES = ["common"];
+
+export default function PreviewCaptionPage() {
+  const router = useRouter();
+  const isEmbed = router.query.embed === "true";
+
+  const previewPage = <CaptionPreviewPage isEmbed={isEmbed} />;
+
+  return (
+    <>
+      <Head>
+        <title>NekoCap - Caption preview</title>
+        <meta name="robots" content="noindex" />
+      </Head>
+      {isEmbed && previewPage}
+      {!isEmbed && <Main>{previewPage}</Main>}
+    </>
+  );
+}
+
+// The caption data lives in the URL hash fragment, which never reaches the
+// server, so this page has no server-side data requirements
+export const getStaticProps: GetStaticProps = NextWrapper.getStaticProps(
+  wrapper.getStaticProps(() => async ({ locale = "en-US" }) => {
+    return {
+      props: {
+        ...(await serverSideTranslations(locale, TRANSLATION_NAMESPACES)),
+      },
+    };
+  }),
+);

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -225,7 +225,17 @@
     "copyEmbedCodeSuccess": "Copied embed code to clipboard!",
     "captionSubmittedBy": "Caption submitted by <captioner>{{creatorName}}</captioner>",
     "downloadNekocapMessage": "For the best caption viewing & creating experience, download the NekoCap extension and view captions directly in {{site}}.",
-    "captionRenderError": "There was an error rendering this caption. Sorry!"
+    "captionRenderError": "There was an error rendering this caption. Sorry!",
+    "preview": {
+      "title": "Caption preview",
+      "instructions": "Preview a NekoCap caption on its video without uploading it. Encode the caption JSON below as base64 and append it to this page's URL:",
+      "supportedSites": "Supported sites: {{sites}}",
+      "urlLengthNote": "Note: links with very large captions may get truncated by some messaging apps.",
+      "decodeError": "The caption data in this link could not be decoded. Check that the link was copied completely.",
+      "tooLargeError": "The caption data in this link is too large to preview.",
+      "invalidFormatError": "The caption data is not in the NekoCap caption format. Expected shape: { \"videoId\": \"...\", \"videoSource\": 0, \"data\": { \"tracks\": [...] } }",
+      "unsupportedSourceError": "This video's site cannot be played on the NekoCap website. Supported sites: {{sites}}"
+    }
   },
   "common": {
     "loading": "Loading...",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -231,6 +231,7 @@
       "instructions": "Preview a NekoCap caption on its video without uploading it. Encode the caption JSON below as base64 and append it to this page's URL:",
       "supportedSites": "Supported sites: {{sites}}",
       "urlLengthNote": "Note: links with very large captions may get truncated by some messaging apps.",
+      "downloadSrt": "Download SRT",
       "decodeError": "The caption data in this link could not be decoded. Check that the link was copied completely.",
       "tooLargeError": "The caption data in this link is too large to preview.",
       "invalidFormatError": "The caption data is not in the NekoCap caption format. Expected shape: { \"videoId\": \"...\", \"videoSource\": 0, \"data\": { \"tracks\": [...] } }",

--- a/src/web/feature/route-types.ts
+++ b/src/web/feature/route-types.ts
@@ -14,6 +14,7 @@ export const routeNames = {
     browse: "/browse/1",
     create: "/create",
     view: "/view/:id",
+    preview: "/view/preview",
     main: "/caption/:id",
   },
 };

--- a/src/web/feature/viewer/caption-preview-page.tsx
+++ b/src/web/feature/viewer/caption-preview-page.tsx
@@ -1,3 +1,5 @@
+import { WSButton } from "@/common/components/ws-button";
+import { exportCaption } from "@/common/feature/caption-editor/export-caption";
 import {
   clearTabData,
   setLoadedCaption,
@@ -9,6 +11,7 @@ import {
   CaptionRendererType,
 } from "@/common/feature/video/types";
 import { videoSourceToProcessorMap } from "@/common/feature/video/utils";
+import DownloadOutlined from "@ant-design/icons/DownloadOutlined";
 import { Alert, Typography } from "antd";
 import { useTranslation } from "next-i18next";
 import { useEffect, useRef, useState } from "react";
@@ -30,6 +33,12 @@ const MessageWrapper = styled.div`
   margin-left: auto;
   margin-right: auto;
   padding: 40px 20px;
+`;
+
+const ActionsWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: 16px 20px;
 `;
 
 const SampleShape = styled.pre`
@@ -175,11 +184,24 @@ export const CaptionPreviewPage = ({
     );
   }
 
+  const handleDownloadSrt = () => {
+    exportCaption({ caption: state.caption, rawCaption: null });
+  };
+
   return (
-    <ViewerPage
-      hasRawCaption={false}
-      isEmbed={isEmbed}
-      showDetails={false}
-    ></ViewerPage>
+    <>
+      <ViewerPage
+        hasRawCaption={false}
+        isEmbed={isEmbed}
+        showDetails={false}
+      ></ViewerPage>
+      {!isEmbed && (
+        <ActionsWrapper>
+          <WSButton icon={<DownloadOutlined />} onClick={handleDownloadSrt}>
+            {t("viewer.preview.downloadSrt")}
+          </WSButton>
+        </ActionsWrapper>
+      )}
+    </>
   );
 };

--- a/src/web/feature/viewer/caption-preview-page.tsx
+++ b/src/web/feature/viewer/caption-preview-page.tsx
@@ -1,0 +1,185 @@
+import {
+  clearTabData,
+  setLoadedCaption,
+  setRenderer,
+  setVideoDimensions,
+} from "@/common/feature/video/actions";
+import {
+  CaptionContainer,
+  CaptionRendererType,
+} from "@/common/feature/video/types";
+import { videoSourceToProcessorMap } from "@/common/feature/video/utils";
+import { Alert, Typography } from "antd";
+import { useTranslation } from "next-i18next";
+import { useEffect, useRef, useState } from "react";
+import { batch, useDispatch } from "react-redux";
+import styled from "styled-components";
+import {
+  getPreviewSupportedSiteNames,
+  parsePreviewHash,
+  PreviewCaptionError,
+} from "./preview-data";
+import { ViewerPage } from "./viewer-page";
+
+const { Title, Paragraph, Text } = Typography;
+
+const TAB_ID = 0;
+
+const MessageWrapper = styled.div`
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 40px 20px;
+`;
+
+const SampleShape = styled.pre`
+  overflow-x: auto;
+  padding: 12px;
+  border-radius: 4px;
+  border: 1px solid rgba(128, 128, 128, 0.35);
+`;
+
+const SAMPLE_PAYLOAD_SHAPE = `{
+  "videoId": "<video id>",
+  "videoSource": 0, // 0: YouTube, 2: Vimeo, 14: Dailymotion
+  "data": {
+    "tracks": [
+      {
+        "cues": [
+          { "start": 1000, "end": 4000, "text": "First caption" },
+          { "start": 5000, "end": 9000, "text": "Second caption" }
+        ]
+      }
+    ]
+  }
+}`;
+
+type PreviewState =
+  | { status: "idle" }
+  | { status: "success"; caption: CaptionContainer }
+  | { status: "error"; error: PreviewCaptionError };
+
+type CaptionPreviewPageProps = {
+  isEmbed: boolean;
+};
+
+export const CaptionPreviewPage = ({
+  isEmbed,
+}: CaptionPreviewPageProps): JSX.Element => {
+  const dispatch = useDispatch();
+  const { t } = useTranslation("common");
+  const [state, setState] = useState<PreviewState>({ status: "idle" });
+  const lastHashRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    const readHash = () => {
+      const hash = globalThis.location.hash;
+      if (hash === lastHashRef.current) {
+        return;
+      }
+      lastHashRef.current = hash;
+      const result = parsePreviewHash(hash);
+      setState(result === undefined ? { status: "idle" } : result);
+    };
+    readHash();
+    globalThis.addEventListener("hashchange", readHash);
+    return () => globalThis.removeEventListener("hashchange", readHash);
+  }, []);
+
+  useEffect(() => {
+    if (state.status !== "success") {
+      return;
+    }
+    const { caption } = state;
+    batch(() => {
+      dispatch(setLoadedCaption({ tabId: TAB_ID, caption }));
+      dispatch(
+        setRenderer({ tabId: TAB_ID, renderer: CaptionRendererType.Default }),
+      );
+      // Set default dimensions immediately so the player is not zero-sized
+      // while the real aspect ratio is being fetched
+      dispatch(
+        setVideoDimensions({
+          tabId: TAB_ID,
+          dimensions: { width: 16, height: 9 },
+        }),
+      );
+    });
+    let cancelled = false;
+    const processor = videoSourceToProcessorMap[caption.videoSource];
+    processor.retrieveVideoDimensions(caption.videoId).then((dimensions) => {
+      if (!cancelled) {
+        dispatch(setVideoDimensions({ tabId: TAB_ID, dimensions }));
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [dispatch, state]);
+
+  // Prevent a preview caption from lingering at tab 0 when navigating to a
+  // regular /view/[id] page in the same client-side session
+  useEffect(() => {
+    return () => {
+      dispatch(clearTabData({ tabId: TAB_ID }));
+    };
+  }, [dispatch]);
+
+  const supportedSites = getPreviewSupportedSiteNames().join(", ");
+
+  if (state.status === "error") {
+    const errorMessage = (() => {
+      switch (state.error) {
+        case PreviewCaptionError.TooLarge:
+          return t("viewer.preview.tooLargeError");
+        case PreviewCaptionError.InvalidBase64:
+        case PreviewCaptionError.InvalidJson:
+          return t("viewer.preview.decodeError");
+        case PreviewCaptionError.UnsupportedSource:
+          return t("viewer.preview.unsupportedSourceError", {
+            sites: supportedSites,
+          });
+        case PreviewCaptionError.InvalidShape:
+        default:
+          return t("viewer.preview.invalidFormatError");
+      }
+    })();
+    return (
+      <MessageWrapper>
+        <Alert
+          type="error"
+          showIcon={true}
+          message={t("viewer.preview.title")}
+          description={errorMessage}
+        />
+      </MessageWrapper>
+    );
+  }
+
+  if (state.status === "idle") {
+    return (
+      <MessageWrapper>
+        <Title>{t("viewer.preview.title")}</Title>
+        <Paragraph>{t("viewer.preview.instructions")}</Paragraph>
+        <Paragraph>
+          <Text code>{"/view/preview#data=<base64 caption JSON>"}</Text>
+        </Paragraph>
+        <SampleShape>{SAMPLE_PAYLOAD_SHAPE}</SampleShape>
+        <Paragraph>
+          {t("viewer.preview.supportedSites", { sites: supportedSites })}
+        </Paragraph>
+        <Paragraph type="secondary">
+          {t("viewer.preview.urlLengthNote")}
+        </Paragraph>
+      </MessageWrapper>
+    );
+  }
+
+  return (
+    <ViewerPage
+      hasRawCaption={false}
+      isEmbed={isEmbed}
+      showDetails={false}
+    ></ViewerPage>
+  );
+};

--- a/src/web/feature/viewer/preview-data.test.ts
+++ b/src/web/feature/viewer/preview-data.test.ts
@@ -1,0 +1,200 @@
+import { VideoSource } from "@/common/feature/video/types";
+import { describe, expect, it } from "vitest";
+import {
+  getPreviewSupportedSiteNames,
+  MAX_PREVIEW_BASE64_LENGTH,
+  parsePreviewHash,
+  PreviewCaptionError,
+} from "./preview-data";
+
+const samplePayload = (overrides: Record<string, unknown> = {}) => ({
+  videoId: "dQw4w9WgXcQ",
+  videoSource: VideoSource.Youtube,
+  data: {
+    tracks: [
+      {
+        cues: [
+          { start: 1000, end: 4000, text: "こんにちは、プレビュー" },
+          { start: 5000, end: 9000, text: "Second cue" },
+        ],
+      },
+    ],
+  },
+  ...overrides,
+});
+
+const encode = (payload: unknown): string =>
+  Buffer.from(JSON.stringify(payload), "utf-8").toString("base64");
+
+const encodeUrlSafe = (payload: unknown): string =>
+  Buffer.from(JSON.stringify(payload), "utf-8").toString("base64url");
+
+describe("parsePreviewHash", () => {
+  it("returns undefined when the hash has no data param", () => {
+    expect(parsePreviewHash("")).toBeUndefined();
+    expect(parsePreviewHash("#")).toBeUndefined();
+    expect(parsePreviewHash("#other=value")).toBeUndefined();
+  });
+
+  it("decodes a standard base64 payload with unicode text", () => {
+    const result = parsePreviewHash(`#data=${encode(samplePayload())}`);
+    expect(result).toMatchObject({
+      status: "success",
+      caption: {
+        videoId: "dQw4w9WgXcQ",
+        videoSource: VideoSource.Youtube,
+        loadedByUser: true,
+      },
+    });
+    if (result?.status !== "success") {
+      throw new Error("expected success");
+    }
+    expect(result.caption.data.tracks[0].cues[0].text).toEqual(
+      "こんにちは、プレビュー",
+    );
+  });
+
+  it("decodes URL-safe base64 without padding", () => {
+    const result = parsePreviewHash(`#data=${encodeUrlSafe(samplePayload())}`);
+    expect(result?.status).toEqual("success");
+  });
+
+  it("preserves + characters instead of decoding them as spaces", () => {
+    // Craft a payload whose base64 encoding contains a "+"
+    let payload = samplePayload();
+    let encoded = encode(payload);
+    for (let i = 0; !encoded.includes("+") && i < 200; i++) {
+      payload = samplePayload({ videoId: `video-${i}` });
+      encoded = encode(payload);
+    }
+    expect(encoded).toContain("+");
+    expect(parsePreviewHash(`#data=${encoded}`)?.status).toEqual("success");
+  });
+
+  it("accepts percent-encoded payloads", () => {
+    const encoded = encodeURIComponent(encode(samplePayload()));
+    expect(parsePreviewHash(`#data=${encoded}`)?.status).toEqual("success");
+  });
+
+  it("ignores whitespace inside the base64 payload", () => {
+    const encoded = encode(samplePayload());
+    const withWhitespace = `${encoded.slice(0, 10)}\n${encoded.slice(10)}`;
+    expect(parsePreviewHash(`#data=${withWhitespace}`)?.status).toEqual(
+      "success",
+    );
+  });
+
+  it("reads the data param when other hash params are present", () => {
+    const encoded = encode(samplePayload());
+    expect(parsePreviewHash(`#foo=bar&data=${encoded}`)?.status).toEqual(
+      "success",
+    );
+  });
+
+  it("rejects oversized payloads", () => {
+    const oversized = "A".repeat(MAX_PREVIEW_BASE64_LENGTH + 1);
+    expect(parsePreviewHash(`#data=${oversized}`)).toEqual({
+      status: "error",
+      error: PreviewCaptionError.TooLarge,
+    });
+  });
+
+  it("rejects malformed base64", () => {
+    expect(parsePreviewHash("#data=!!!not-base64!!!")).toEqual({
+      status: "error",
+      error: PreviewCaptionError.InvalidBase64,
+    });
+  });
+
+  it("rejects base64 that does not contain JSON", () => {
+    const encoded = Buffer.from("not json at all", "utf-8").toString("base64");
+    expect(parsePreviewHash(`#data=${encoded}`)).toEqual({
+      status: "error",
+      error: PreviewCaptionError.InvalidJson,
+    });
+  });
+
+  it.each([
+    ["missing videoId", samplePayload({ videoId: undefined })],
+    ["empty videoId", samplePayload({ videoId: "" })],
+    ["non-numeric videoSource", samplePayload({ videoSource: "0" })],
+    ["missing data", samplePayload({ data: undefined })],
+    ["missing tracks", samplePayload({ data: {} })],
+    ["empty tracks", samplePayload({ data: { tracks: [] } })],
+    [
+      "track without cues",
+      samplePayload({ data: { tracks: [{ settings: {} }] } }),
+    ],
+    [
+      "cue with non-numeric start",
+      samplePayload({
+        data: { tracks: [{ cues: [{ start: "1", end: 2, text: "a" }] }] },
+      }),
+    ],
+    [
+      "cue with negative start",
+      samplePayload({
+        data: { tracks: [{ cues: [{ start: -1, end: 2, text: "a" }] }] },
+      }),
+    ],
+    [
+      "cue with non-string text",
+      samplePayload({
+        data: { tracks: [{ cues: [{ start: 1, end: 2, text: 3 }] }] },
+      }),
+    ],
+  ])("rejects invalid shape: %s", (description, payload) => {
+    expect(parsePreviewHash(`#data=${encode(payload)}`)).toEqual({
+      status: "error",
+      error: PreviewCaptionError.InvalidShape,
+    });
+  });
+
+  it("rejects sources that cannot be watched on the NekoCap site", () => {
+    const result = parsePreviewHash(
+      `#data=${encode(samplePayload({ videoSource: VideoSource.Netflix }))}`,
+    );
+    expect(result).toEqual({
+      status: "error",
+      error: PreviewCaptionError.UnsupportedSource,
+    });
+  });
+
+  it("clamps the number of tracks to the maximum", () => {
+    const track = {
+      cues: [{ start: 0, end: 1000, text: "cue" }],
+    };
+    const payload = samplePayload({
+      data: { tracks: Array.from({ length: 15 }, () => track) },
+    });
+    const result = parsePreviewHash(`#data=${encode(payload)}`);
+    if (result?.status !== "success") {
+      throw new Error("expected success");
+    }
+    expect(result.caption.data.tracks).toHaveLength(10);
+  });
+
+  it("rejects payloads with too many cues in total", () => {
+    const cues = Array.from({ length: 20001 }, (unused, index) => ({
+      start: index,
+      end: index + 1,
+      text: "c",
+    }));
+    const payload = samplePayload({ data: { tracks: [{ cues }] } });
+    expect(parsePreviewHash(`#data=${encode(payload)}`)).toEqual({
+      status: "error",
+      error: PreviewCaptionError.TooLarge,
+    });
+  });
+});
+
+describe("getPreviewSupportedSiteNames", () => {
+  it("lists the sites that can be watched on the NekoCap website", () => {
+    const names = getPreviewSupportedSiteNames();
+    expect(names).toContain("YouTube");
+    expect(names).toContain("Vimeo");
+    expect(names).toContain("Dailymotion");
+    // Names are deduplicated
+    expect(new Set(names).size).toEqual(names.length);
+  });
+});

--- a/src/web/feature/viewer/preview-data.ts
+++ b/src/web/feature/viewer/preview-data.ts
@@ -1,0 +1,178 @@
+import type {
+  CaptionDataContainer,
+  Track,
+} from "@/common/caption-parsers/types";
+import { MAX_TRACKS } from "@/common/feature/video/constants";
+import { CaptionContainer, VideoSource } from "@/common/feature/video/types";
+import { videoSourceToProcessorMap } from "@/common/feature/video/utils";
+
+/**
+ * Caps to keep decoding and validation of untrusted preview payloads fast.
+ * ~2 million base64 characters is roughly 1.5 MB of decoded JSON.
+ */
+export const MAX_PREVIEW_BASE64_LENGTH = 2_000_000;
+export const MAX_PREVIEW_TOTAL_CUES = 20_000;
+
+export enum PreviewCaptionError {
+  TooLarge = "tooLarge",
+  InvalidBase64 = "invalidBase64",
+  InvalidJson = "invalidJson",
+  InvalidShape = "invalidShape",
+  UnsupportedSource = "unsupportedSource",
+}
+
+export type PreviewCaptionResult =
+  | { status: "success"; caption: CaptionContainer }
+  | { status: "error"; error: PreviewCaptionError };
+
+const errorResult = (error: PreviewCaptionError): PreviewCaptionResult => ({
+  status: "error",
+  error,
+});
+
+/**
+ * Decodes base64 (standard or URL-safe alphabet, padding optional) to a UTF-8 string.
+ * Throws on invalid base64 or invalid UTF-8.
+ */
+const decodeBase64Utf8 = (input: string): string => {
+  const normalized = input
+    .replace(/\s/g, "")
+    .replace(/-/g, "+")
+    .replace(/_/g, "/");
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+  const binary = globalThis.atob(padded);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+};
+
+const isValidTrack = (track: unknown): track is Track => {
+  if (typeof track !== "object" || track === null) {
+    return false;
+  }
+  const cues = (track as Track).cues;
+  if (!Array.isArray(cues)) {
+    return false;
+  }
+  return cues.every(
+    (cue) =>
+      typeof cue === "object" &&
+      cue !== null &&
+      Number.isFinite(cue.start) &&
+      cue.start >= 0 &&
+      Number.isFinite(cue.end) &&
+      typeof cue.text === "string",
+  );
+};
+
+const validatePayload = (payload: unknown): PreviewCaptionResult => {
+  if (typeof payload !== "object" || payload === null) {
+    return errorResult(PreviewCaptionError.InvalidShape);
+  }
+  const { videoId, videoSource, data } = payload as {
+    videoId: unknown;
+    videoSource: unknown;
+    data: unknown;
+  };
+  if (typeof videoId !== "string" || videoId.length <= 0) {
+    return errorResult(PreviewCaptionError.InvalidShape);
+  }
+  if (typeof videoSource !== "number" || !Number.isInteger(videoSource)) {
+    return errorResult(PreviewCaptionError.InvalidShape);
+  }
+  if (typeof data !== "object" || data === null) {
+    return errorResult(PreviewCaptionError.InvalidShape);
+  }
+  const processor = videoSourceToProcessorMap[videoSource as VideoSource];
+  if (!processor || !processor.canWatchInNekoCapSite) {
+    return errorResult(PreviewCaptionError.UnsupportedSource);
+  }
+  const { tracks, settings } = data as CaptionDataContainer;
+  if (!Array.isArray(tracks) || tracks.length <= 0) {
+    return errorResult(PreviewCaptionError.InvalidShape);
+  }
+  const clampedTracks = tracks.slice(0, MAX_TRACKS);
+  if (!clampedTracks.every(isValidTrack)) {
+    return errorResult(PreviewCaptionError.InvalidShape);
+  }
+  const totalCues = clampedTracks.reduce(
+    (total, track) => total + track.cues.length,
+    0,
+  );
+  if (totalCues > MAX_PREVIEW_TOTAL_CUES) {
+    return errorResult(PreviewCaptionError.TooLarge);
+  }
+  const caption: CaptionContainer = {
+    videoId,
+    videoSource: videoSource as VideoSource,
+    data: { tracks: clampedTracks, settings },
+    loadedByUser: true,
+    userLike: null,
+    userDislike: null,
+  };
+  return { status: "success", caption };
+};
+
+/**
+ * Extracts the `data` param from a URL hash fragment.
+ * URLSearchParams is deliberately avoided: it decodes "+" to a space, which
+ * would silently corrupt standard base64 payloads.
+ * Returns undefined when the hash carries no `data` param at all.
+ */
+export const extractPreviewData = (hash: string): string | undefined => {
+  const match = hash.replace(/^#/, "").match(/(?:^|&)data=([^&]*)/);
+  if (!match) {
+    return undefined;
+  }
+  let raw = match[1];
+  try {
+    raw = decodeURIComponent(raw);
+  } catch (e) {
+    // Keep the raw value: base64 characters do not require percent-encoding
+  }
+  return raw;
+};
+
+/**
+ * Parses a viewer preview hash fragment (`#data=<base64 caption JSON>`) into
+ * a renderable CaptionContainer. The payload must be a base64 encoded JSON
+ * object of the shape { videoId, videoSource, data: { tracks: [...] } }.
+ * Returns undefined when the hash has no `data` param.
+ */
+export const parsePreviewHash = (
+  hash: string,
+): PreviewCaptionResult | undefined => {
+  const encodedData = extractPreviewData(hash);
+  if (encodedData === undefined) {
+    return undefined;
+  }
+  if (encodedData.length > MAX_PREVIEW_BASE64_LENGTH) {
+    return errorResult(PreviewCaptionError.TooLarge);
+  }
+  let jsonString: string;
+  try {
+    jsonString = decodeBase64Utf8(encodedData);
+  } catch (e) {
+    return errorResult(PreviewCaptionError.InvalidBase64);
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(jsonString);
+  } catch (e) {
+    return errorResult(PreviewCaptionError.InvalidJson);
+  }
+  return validatePayload(payload);
+};
+
+/**
+ * Display names of video sites whose videos can be watched on the NekoCap
+ * website, for use in preview instructions and error messages.
+ */
+export const getPreviewSupportedSiteNames = (): string[] => {
+  return Array.from(
+    new Set(
+      Object.values(videoSourceToProcessorMap)
+        .filter((processor) => processor.canWatchInNekoCapSite)
+        .map((processor) => processor.name),
+    ),
+  );
+};

--- a/src/web/feature/viewer/viewer-page.tsx
+++ b/src/web/feature/viewer/viewer-page.tsx
@@ -117,9 +117,10 @@ const FullScreenButton = styled.div`
 `;
 
 export type ViewerPageProps = {
-  captionId: string;
+  captionId?: string;
   hasRawCaption?: boolean;
   isEmbed: boolean;
+  showDetails?: boolean;
 };
 
 function videoPreferencesReducer(
@@ -139,6 +140,7 @@ function videoPreferencesReducer(
 export const ViewerPage = ({
   hasRawCaption = undefined,
   isEmbed,
+  showDetails = true,
 }: ViewerPageProps): JSX.Element => {
   const router = useRouter();
   const dispatch = useDispatch();
@@ -327,7 +329,7 @@ export const ViewerPage = ({
             />
           </FullScreenWrapper>
         </FullScreen>
-        {caption && !isEmbed && (
+        {caption && !isEmbed && showDetails && (
           <DetailsWrapper>
             <Row gutter={[16, 16]}>
               <Col md={16}>


### PR DESCRIPTION
## Summary
This PR adds a new caption preview feature that allows users to preview NekoCap captions on their videos without uploading them to the platform. Captions are encoded as base64 in the URL hash fragment and decoded client-side for immediate preview.

## Key Changes
- **New preview page** (`pages/view/preview.tsx`): Dedicated route at `/view/preview` that handles caption preview rendering
- **Preview data parsing** (`src/web/feature/viewer/preview-data.ts`): Core logic for decoding and validating base64-encoded caption JSON from URL hash fragments, including:
  - Base64 decoding with support for standard and URL-safe alphabets
  - Comprehensive validation of caption structure and constraints
  - Support for multiple video sources (YouTube, Vimeo, Dailymotion)
  - Size limits to prevent abuse (2MB base64, 20k total cues)
- **Preview UI component** (`src/web/feature/viewer/caption-preview-page.tsx`): User-facing component that displays instructions, error messages, or the caption preview
- **Comprehensive test suite** (`src/web/feature/viewer/preview-data.test.ts`): 200+ lines of tests covering decoding, validation, error handling, and edge cases
- **ViewerPage updates**: Made `captionId` optional and added `showDetails` prop to support preview-specific rendering
- **Localization**: Added English translations for preview instructions, error messages, and supported sites list
- **Route registration**: Added `/view/preview` to route names

## Notable Implementation Details
- URL hash fragment is used instead of query parameters to keep caption data client-side only (never sent to server)
- Robust base64 decoding handles standard base64, URL-safe base64, missing padding, and percent-encoding
- Whitespace in base64 payloads is automatically stripped for flexibility
- Validation includes shape checking, source compatibility, and size constraints
- Video dimensions are fetched asynchronously while showing default 16:9 aspect ratio
- Preview captions are cleared when navigating away to prevent state leakage
- Page is marked with `noindex` robots meta tag to prevent search engine indexing

https://claude.ai/code/session_01NaBzGgAwok9LcNfWzfG4bm