### PR TITLE
Extract raw caption compression logic into reusable utility

### DIFF
--- a/src/extension/background/feature/caption-editor/sagas.ts
+++ b/src/extension/background/feature/caption-editor/sagas.ts
@@ -103,9 +103,9 @@ import {
 } from "@/common/types";
 import { getStringByteLength } from "@/common/utils";
 import { CaptionMutators } from "@/extension/content/feature/editor/utils";
-import { compressToBase64 as lzCompress } from "lz-string";
 import { SUPPORTED_EXPORT_FORMATS } from "./constants";
 import {
+  compressRawCaptionForUpload,
   getCaptionContainersFromFile,
   getLocalCaptionDataFromStorage,
   saveLocalCaptionDataToStorage,
@@ -490,12 +490,13 @@ function* submitCaptionSaga({ payload }: ThunkedPayloadAction<SubmitCaption>) {
     languageCode,
     translatedTitle,
   };
-  const rawCaption = yield select(tabEditorRawDataSelector(tabId));
-  // The raw caption will be compressed locally and decompressed on retrieval
-  const processedRawCaption = { ...rawCaption };
-  if (processedRawCaption.data) {
-    processedRawCaption.data = lzCompress(rawCaption.data);
-  }
+  const rawCaption: RawCaptionData | undefined = yield select(
+    tabEditorRawDataSelector(tabId),
+  );
+  // Spreading a missing raw caption used to produce an empty object here, which
+  // made the server try to store an empty raw file and report the whole
+  // submission as failed even though the caption itself had already been saved
+  const processedRawCaption = compressRawCaptionForUpload(rawCaption);
   const response: UploadResult = yield call(
     [Locator.provider(), "submitCaption"],
     {
@@ -543,17 +544,12 @@ function* updateUploadedCaptionSaga({
     rawCaption = convertedCaptions.rawCaptionData;
     captionData = convertedCaptions.captionData;
   }
-  // The raw caption will be compressed locally and decompressed on retrieval
   if (rawCaption) {
     captionData = undefined;
   } else if (captionData) {
     rawCaption = undefined;
   }
-  let processedRawCaption: RawCaptionData | undefined = undefined;
-  if (rawCaption && rawCaption.data) {
-    processedRawCaption = { ...rawCaption };
-    processedRawCaption.data = lzCompress(rawCaption.data);
-  }
+  const processedRawCaption = compressRawCaptionForUpload(rawCaption);
   const response: UploadResponse = yield call(
     [Locator.provider(), "updateCaption"],
     {

--- a/src/extension/background/feature/caption-editor/utils.test.ts
+++ b/src/extension/background/feature/caption-editor/utils.test.ts
@@ -1,0 +1,36 @@
+import { CaptionFileFormat } from "@/common/types";
+import { decompressFromBase64 } from "lz-string";
+import { describe, expect, it } from "vitest";
+import { compressRawCaptionForUpload } from "./utils";
+
+describe("compressRawCaptionForUpload", () => {
+  it("returns nothing when there is no raw caption", () => {
+    expect(compressRawCaptionForUpload(undefined)).toBeUndefined();
+  });
+
+  it("returns nothing when the raw caption has no data", () => {
+    // Captions written in the editor have no raw file behind them. Sending a
+    // raw caption here makes the server reject the whole submission because it
+    // cannot store an empty raw file
+    expect(
+      compressRawCaptionForUpload({ type: CaptionFileFormat.ass, data: "" }),
+    ).toBeUndefined();
+  });
+
+  it("compresses the data of a raw caption", () => {
+    const data = "[Script Info]\nScriptType: v4.00+\n";
+    const result = compressRawCaptionForUpload({
+      type: CaptionFileFormat.ass,
+      data,
+    });
+    expect(result?.type).toEqual(CaptionFileFormat.ass);
+    expect(result?.data).not.toEqual(data);
+    expect(decompressFromBase64(result?.data || "")).toEqual(data);
+  });
+
+  it("does not modify the raw caption it is given", () => {
+    const rawCaption = { type: CaptionFileFormat.ass, data: "some data" };
+    compressRawCaptionForUpload(rawCaption);
+    expect(rawCaption.data).toEqual("some data");
+  });
+});

--- a/src/extension/background/feature/caption-editor/utils.ts
+++ b/src/extension/background/feature/caption-editor/utils.ts
@@ -6,6 +6,7 @@ import { isInExtension } from "@/common/client-utils";
 import { EditorStorage } from "@/common/feature/caption-editor/types";
 import { RawCaptionData, VideoSource } from "@/common/feature/video/types";
 import { CaptionFileFormat } from "@/common/types";
+import { compressToBase64 as lzCompress } from "lz-string";
 
 export const EDITOR_STORAGE_KEY = "editor";
 
@@ -44,6 +45,22 @@ export async function saveLocalCaptionDataToStorage(result: EditorStorage) {
   } else {
     globalThis.localStorage.setItem(EDITOR_STORAGE_KEY, JSON.stringify(result));
   }
+}
+
+/**
+ * Prepares a raw caption for submission to the server.
+ * Captions without raw data (anything written in the editor and any non ass
+ * file) must not send a raw caption at all: the server would try to store an
+ * empty raw file, which the file upload endpoint rejects.
+ * The data is compressed here and decompressed on retrieval.
+ */
+export function compressRawCaptionForUpload(
+  rawCaption?: RawCaptionData,
+): RawCaptionData | undefined {
+  if (!rawCaption || !rawCaption.data) {
+    return undefined;
+  }
+  return { ...rawCaption, data: lzCompress(rawCaption.data) };
 }
 
 export function getCaptionContainersFromFile({


### PR DESCRIPTION
## Summary
Refactored raw caption compression logic into a dedicated utility function to eliminate code duplication and fix a bug where undefined raw captions were being processed incorrectly.

## Key Changes
- Created `compressRawCaptionForUpload()` utility function in `utils.ts` that:
  - Returns `undefined` for missing or empty raw captions (preventing server-side failures)
  - Compresses non-empty caption data using lz-string base64 encoding
  - Creates a new object to avoid mutating the input
  
- Updated `submitCaptionSaga()` to use the new utility instead of inline compression logic
- Updated `updateUploadedCaptionSaga()` to use the new utility instead of inline compression logic
- Added comprehensive unit tests covering edge cases:
  - Undefined raw captions
  - Empty caption data
  - Successful compression and decompression
  - Input immutability

## Notable Details
The refactoring fixes a subtle bug where spreading an undefined raw caption (`{ ...undefined }`) would produce an empty object `{}`, causing the server to attempt storing an empty raw file and reject the entire submission despite the caption data being valid. The new utility explicitly returns `undefined` in these cases, preventing the server error.

https://claude.ai/code/session_01DXbXw2g71VP5b888nwQqwh